### PR TITLE
style: remove border radius from images in content

### DIFF
--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -37,10 +37,6 @@ body {
   @apply text-xl font-bold p-0;
 }
 
-.content img {
-  @apply rounded;
-}
-
 .content ul {
   @apply list-disc pl-4;
 }


### PR DESCRIPTION
borders look awful
![Screenshot 2022-09-14 164036](https://user-images.githubusercontent.com/39843372/190186140-2dd2f8cb-5bcc-46bb-a85c-7442933c1c86.png)

let's try without them

![Screenshot 2022-09-14 164100](https://user-images.githubusercontent.com/39843372/190186292-ae79eca2-d7c8-4591-a14d-0c80955bb183.png)
