### PR TITLE
fix: sign-up button shows login text

### DIFF
--- a/apps/web/src/components/auth/sign-up-form/sign-up-form.view.tsx
+++ b/apps/web/src/components/auth/sign-up-form/sign-up-form.view.tsx
@@ -97,7 +97,7 @@ export const SignUpForm = observer<Props>(({ invite }) => {
           type="submit"
           className="px-3 py-1 rounded bg-blue-500 text-white cursor-pointer"
         >
-          Войти
+          Зарегистрироваться
         </button>
       </div>
     </Form>


### PR DESCRIPTION
Use "Зарегистрироваться" instead of "Войти"